### PR TITLE
Add SEO pages and sitemap generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Won Buddhism of Richmond
+
+This is a Next.js 8 site for the Won Buddhism temple in Richmond, VA.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+For production deployments (such as Vercel) use:
+
+```bash
+npm run build
+```
+
+The build script also regenerates `static/sitemap.xml`.
+
+## SEO Pages and Sitemap
+
+Keyword focused pages are listed in `seo-pages.json`. After adding or updating pages, regenerate the sitemap:
+
+```bash
+npm run generate-sitemap
+```
+
+The sitemap is written to `static/sitemap.xml` and referenced from `static/robots.txt`.

--- a/components/SeoPage.js
+++ b/components/SeoPage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Head from 'next/head';
+
+export default function SeoPage({ title, description, heading, children }) {
+  return (
+    <div className="SeoPage">
+      <Head>
+        <title>{title}</title>
+        {description && <meta name="description" content={description} />}
+      </Head>
+      <div className="inner-wrapper narrow">
+        <h1>{heading}</h1>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/sections/Home/Footer/index.css
+++ b/components/sections/Home/Footer/index.css
@@ -15,3 +15,12 @@ footer p {
 footer img {
   height: 40px;
 }
+
+.seo-links {
+  margin-top: 12px;
+}
+
+.seo-links a {
+  color: #ffd700;
+  margin: 0 8px;
+}

--- a/components/sections/Home/Footer/index.js
+++ b/components/sections/Home/Footer/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import seoPages from "../../../../seo-pages.json";
 
 import "./index.css";
 
@@ -7,6 +8,11 @@ export default function Footer({ footer }) {
     <footer>
       <img src="/static/logo.png" alt="company logo" />
       <p>{footer.copyright}</p>
+      <nav className="seo-links">
+        {seoPages.map(page => (
+          <a key={page.slug} href={`/${page.slug}`}>{page.heading}</a>
+        ))}
+      </nav>
     </footer>
   );
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "private": false,
   "scripts": {
     "dev": "next",
+    "build": "next build && npm run generate-sitemap",
     "start": "next start -p $PORT",
-    "heroku-postbuild": "next build"
+    "generate-sitemap": "node scripts/generate-sitemap.js"
   },
   "dependencies": {
     "@sanity/client": "^0.147.3",

--- a/pages/buddhist-temple-near-me.js
+++ b/pages/buddhist-temple-near-me.js
@@ -1,0 +1,15 @@
+import pages from '../seo-pages.json';
+import SeoPage from '../components/SeoPage';
+import './index.css';
+
+const data = pages.find(p => p.slug === 'buddhist-temple-near-me');
+
+export default function BuddhistTempleNearMe() {
+  return (
+    <SeoPage title={data.title} description={data.description} heading={data.heading}>
+      <p>If you are searching for a Buddhist temple near you in the Richmond area, our temple offers a peaceful place to learn and practice.</p>
+      <p>Visit us for meditation, services, and community events.</p>
+      <p><a href="/">Back to Home</a></p>
+    </SeoPage>
+  );
+}

--- a/pages/buddhist-temple-richmond-va.js
+++ b/pages/buddhist-temple-richmond-va.js
@@ -1,0 +1,15 @@
+import pages from '../seo-pages.json';
+import SeoPage from '../components/SeoPage';
+import './index.css';
+
+const data = pages.find(p => p.slug === 'buddhist-temple-richmond-va');
+
+export default function BuddhistTempleRichmondVa() {
+  return (
+    <SeoPage title={data.title} description={data.description} heading={data.heading}>
+      <p>Won Buddhism of Richmond is a Korean Buddhist temple located in Mechanicsville, just outside Richmond. Our temple offers meditation services, Dharma talks, and community gatherings.</p>
+      <p>Everyone is welcome to visit and learn about Buddhism in a friendly environment.</p>
+      <p><a href="/">Back to Home</a></p>
+    </SeoPage>
+  );
+}

--- a/pages/meditation-classes-richmond-va.js
+++ b/pages/meditation-classes-richmond-va.js
@@ -1,0 +1,15 @@
+import pages from '../seo-pages.json';
+import SeoPage from '../components/SeoPage';
+import './index.css';
+
+const data = pages.find(p => p.slug === 'meditation-classes-richmond-va');
+
+export default function MeditationClassesRichmondVa() {
+  return (
+    <SeoPage title={data.title} description={data.description} heading={data.heading}>
+      <p>We hold regular meditation classes open to beginners and experienced practitioners alike. Classes include guided meditation and discussion of Buddhist teachings.</p>
+      <p>Check our schedule or contact us for the latest times.</p>
+      <p><a href="/">Back to Home</a></p>
+    </SeoPage>
+  );
+}

--- a/pages/tai-chi-richmond-va.js
+++ b/pages/tai-chi-richmond-va.js
@@ -1,0 +1,14 @@
+import pages from '../seo-pages.json';
+import SeoPage from '../components/SeoPage';
+import './index.css';
+
+const data = pages.find(p => p.slug === 'tai-chi-richmond-va');
+
+export default function TaiChiRichmondVa() {
+  return (
+    <SeoPage title={data.title} description={data.description} heading={data.heading}>
+      <p>Our temple offers Tai Chi classes to promote balance, health, and mindfulness. Classes are taught by experienced instructors and open to all skill levels.</p>
+      <p><a href="/">Back to Home</a></p>
+    </SeoPage>
+  );
+}

--- a/pages/won-buddhism.js
+++ b/pages/won-buddhism.js
@@ -1,0 +1,15 @@
+import pages from '../seo-pages.json';
+import SeoPage from '../components/SeoPage';
+import './index.css';
+
+const data = pages.find(p => p.slug === 'won-buddhism');
+
+export default function WonBuddhismPage() {
+  return (
+    <SeoPage title={data.title} description={data.description} heading={data.heading}>
+      <p>Won Buddhism is a modern Buddhist movement from Korea that emphasizes using our mind well in everyday life. At Won Buddhism of Richmond we study and practice these teachings together.</p>
+      <p>Come explore Won Buddhism with us through meditation, Dharma talks, and community programs.</p>
+      <p><a href="/">Back to Home</a></p>
+    </SeoPage>
+  );
+}

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+const pages = require('../seo-pages.json');
+
+const baseUrl = process.env.SITE_URL || 'https://www.richmond-va.wonbuddhism.org';
+
+const urls = [''].concat(pages.map(p => p.slug));
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  urls
+    .map(slug => `  <url>\n    <loc>${baseUrl}/${slug}</loc>\n  </url>`) 
+    .join('\n') +
+  '\n</urlset>\n';
+
+fs.writeFileSync(path.join(__dirname, '..', 'static', 'sitemap.xml'), xml);
+console.log('sitemap.xml generated with', urls.length, 'urls');

--- a/seo-pages.json
+++ b/seo-pages.json
@@ -1,0 +1,32 @@
+[
+  {
+    "slug": "buddhist-temple-richmond-va",
+    "title": "Buddhist Temple in Richmond VA | Won Buddhism of Richmond",
+    "description": "Discover our Korean Buddhist temple in Richmond, Virginia. Join meditation classes, services, and community events.",
+    "heading": "Buddhist Temple in Richmond, VA"
+  },
+  {
+    "slug": "meditation-classes-richmond-va",
+    "title": "Meditation Classes in Richmond VA | Won Buddhism of Richmond",
+    "description": "Find weekly meditation classes and learn Won Buddhist practices at our Richmond temple.",
+    "heading": "Meditation Classes in Richmond, VA"
+  },
+  {
+    "slug": "buddhist-temple-near-me",
+    "title": "Buddhist Temple Near Me | Won Buddhism of Richmond",
+    "description": "Looking for a nearby Buddhist temple? Visit our welcoming community in Richmond, Virginia.",
+    "heading": "Buddhist Temple Near Me"
+  },
+  {
+    "slug": "tai-chi-richmond-va",
+    "title": "Tai Chi in Richmond VA | Won Buddhism of Richmond",
+    "description": "Improve balance and mindfulness with our Tai Chi classes in Richmond, VA.",
+    "heading": "Tai Chi in Richmond, VA"
+  },
+  {
+    "slug": "won-buddhism",
+    "title": "Won Buddhism | Korean Buddhist Temple in Richmond",
+    "description": "Learn about Won Buddhism and how we practice it at our Richmond temple.",
+    "heading": "Won Buddhism"
+  }
+]

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.richmond-va.wonbuddhism.org/static/sitemap.xml

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.richmond-va.wonbuddhism.org/</loc>
+  </url>
+  <url>
+    <loc>https://www.richmond-va.wonbuddhism.org/buddhist-temple-richmond-va</loc>
+  </url>
+  <url>
+    <loc>https://www.richmond-va.wonbuddhism.org/meditation-classes-richmond-va</loc>
+  </url>
+  <url>
+    <loc>https://www.richmond-va.wonbuddhism.org/buddhist-temple-near-me</loc>
+  </url>
+  <url>
+    <loc>https://www.richmond-va.wonbuddhism.org/tai-chi-richmond-va</loc>
+  </url>
+  <url>
+    <loc>https://www.richmond-va.wonbuddhism.org/won-buddhism</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- create keyword-focused SEO pages
- centralize SEO metadata
- add sitemap generation script and robots.txt
- link SEO pages from footer
- document setup steps
- update build script for Vercel

## Testing
- `npm run generate-sitemap`


------
https://chatgpt.com/codex/tasks/task_e_6865543f04d8832ab9fdb4a96832a09b